### PR TITLE
Add DEV BUILD indicators

### DIFF
--- a/Consultify-salon/public/index.html
+++ b/Consultify-salon/public/index.html
@@ -35,7 +35,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <title>Consultify</title>
+  <title>Consultify - DEV BUILD</title>
 </head>
 
 <body>

--- a/Consultify-salon/src/assets/css/style.css
+++ b/Consultify-salon/src/assets/css/style.css
@@ -521,7 +521,8 @@ button.close-menu svg {
 
 /* SignUp */
 .bg-color {
-  background: linear-gradient(90deg, #0b4a4a 0%, #427272 100%);
+  /* override dashboard background for development builds */
+  background: #e6f7ff;
   /* height: 100vh; */
 }
 
@@ -7086,4 +7087,16 @@ label {
 
 .text-primary {
   color: #427272!important;
+}
+
+/* Visible marker for development builds */
+.dev-build-overlay {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  font-size: 48px;
+  font-weight: bold;
+  color: rgba(0, 0, 0, 0.3);
+  z-index: 9999;
+  pointer-events: none;
 }

--- a/Consultify-salon/src/pages/DashboardOption.js
+++ b/Consultify-salon/src/pages/DashboardOption.js
@@ -398,6 +398,7 @@ export default function DashboardOption() {
           </div>
         </div>
       </div>
+      <div className="dev-build-overlay">DEV BUILD</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update title to show DEV BUILD
- change dashboard background to pale blue
- display a DEV BUILD overlay on the salon dashboard

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68474d7e49bc832db5fec3cc1540051b