### PR TITLE
Fix consultation presets link and filter width

### DIFF
--- a/Consultify-salon/Consultation.js
+++ b/Consultify-salon/Consultation.js
@@ -392,7 +392,7 @@ const Consultation = () => {
       {/* new consultation  */}
       {/* search list */}
       <section>
-        <div className="consultation-presents-tabs mt-4">
+        <div className="consultation-presets-tabs mt-4">
           <div className="d-flex">
             <Form.Select
               aria-label="Default select example"

--- a/Consultify-salon/src/Routes/Routes.js
+++ b/Consultify-salon/src/Routes/Routes.js
@@ -198,7 +198,7 @@ const RoutesPage = () => {
 
           <Route path="/pre-care" element={<PreCare />} />
           <Route
-            path="/consultation-presents"
+            path="/consultation-presets"
             element={<ConsultationPresents />}
           />
           <Route path="/settings" element={<Settings />} />

--- a/Consultify-salon/src/assets/css/responsive.css
+++ b/Consultify-salon/src/assets/css/responsive.css
@@ -1109,7 +1109,7 @@ button.submit_big_button {
     height: 125px;
    
 }
-.consultation-presents-tabs select.form-select {
+.consultation-presets-tabs select.form-select {
     width: 100%;
     max-width: 100%;
     margin: 0;
@@ -1272,13 +1272,13 @@ ul.yes_no_main {
     margin-top: 12px;
    
 }
-    .consultation-presents-tabs .d-flex {
+    .consultation-presets-tabs .d-flex {
         gap: 8px;
         flex-wrap: wrap;
         display: block !important;
         width: 100%;
     }
-    .consultation-presents-tabs .expand-field {
+    .consultation-presets-tabs .expand-field {
     margin-top: 14px;
     width: 100%;
 }
@@ -1287,7 +1287,7 @@ ul.yes_no_main {
     margin-bottom: 15px;
    
 } */
-.consultation-presents-tabs button.active-tab {
+.consultation-presets-tabs button.active-tab {
    
     margin-bottom: 10px;
 }
@@ -1373,7 +1373,7 @@ button.trash-btn.bin {
     display: flex!important;
     justify-content: end;
 }
-    .consultation-presents-tabs {
+    .consultation-presets-tabs {
         display: flex;
         justify-content: center;
         align-items: center;
@@ -1548,11 +1548,11 @@ span.profile-view-mob {
 section.search-list-part.presents .consult-view-btn {
     width: 100%!important;
 }
-.consultation-presents-tabs.precare.d-block .preacknowledgement-box {
+.consultation-presets-tabs.precare.d-block .preacknowledgement-box {
     padding: 15px 20px;
     display: block;
 }
-.consultation-presents-tabs.precare.d-block select {
+.consultation-presets-tabs.precare.d-block select {
     margin: 9px 0;
 }
 .submit-btn.schedule.p-0 button {

--- a/Consultify-salon/src/assets/css/style.css
+++ b/Consultify-salon/src/assets/css/style.css
@@ -4785,7 +4785,7 @@ button.create-form {
 .client_consulation .css-t3ipsp-control:hover {
   border-color: #0a4949;
 }
-.consultation-presents-tabs select.form-select:focus {
+.consultation-presets-tabs select.form-select:focus {
   color: #000 !important;
 }
 .client_consulation .css-t3ipsp-control {
@@ -5463,7 +5463,7 @@ span.formik-errors {
   height: 40px; */
 }
 
-.consultation-presents-tabs button {
+.consultation-presets-tabs button {
   border-radius: 28px;
   background: var(--white, #fff);
   box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.25);
@@ -5476,23 +5476,23 @@ span.formik-errors {
   padding: 11px 15px;
 }
 
-.consultation-presents-tabs button span {
+.consultation-presets-tabs button span {
   font-weight: 400 !important;
   line-height: normal;
 }
-.consultation-presents-tabs button.active-tab {
+.consultation-presets-tabs button.active-tab {
   border-radius: 28px;
   background: #427272;
   box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.25);
   color: #fff;
   font-weight: 400;
 }
-.consultation-presents-tabs {
+.consultation-presets-tabs {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
 }
-.consultation-presents-tabs .d-flex {
+.consultation-presets-tabs .d-flex {
   gap: 20px;
   flex-wrap: wrap;
 }
@@ -6338,7 +6338,7 @@ h4.activity-heading {
   font-size: 15px;
 }
 
-.consultation-presents-tabs select.form-select {
+.consultation-presets-tabs select.form-select {
   border-radius: 28px;
   background-color: var(--white, #fff);
   box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.25);
@@ -6347,7 +6347,7 @@ h4.activity-heading {
   border: none;
   font-weight: 400;
   line-height: normal;
-  max-width: 235px;
+  width: 350px;
   padding: 12px 20px;
   transition: 0.5s ease;
 }

--- a/Consultify-salon/src/components/Layout/MyAcoountLayout.js
+++ b/Consultify-salon/src/components/Layout/MyAcoountLayout.js
@@ -168,11 +168,11 @@ const MyAcoountLayout = ({ children, DidYouKnow }) => {
                       </Link>
                       <Link
                         className={
-                          window.location.pathname == "/consultation-presents"
+                          window.location.pathname == "/consultation-presets"
                             ? "setting-active"
                             : " "
                         }
-                        to="/consultation-presents"
+                        to="/consultation-presets"
                       >
 
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/Consultify-salon/src/pages/Consultation.js
+++ b/Consultify-salon/src/pages/Consultation.js
@@ -570,7 +570,7 @@ Completed
             </div>
           </Col>
           <Col lg={5} className="d-flex justify-content-end align-items-start">
-            <Link to="/consultation-presents" className="consult-btn mob-hide">
+            <Link to="/consultation-presets" className="consult-btn mob-hide">
               Consultation Settings
             </Link>
             <div className="button-link ms-2">
@@ -591,7 +591,7 @@ Completed
       {selecteddrop == 0 && (
         <>
           <section>
-            <div className="consultation-presents-tabs mt-4">
+            <div className="consultation-presets-tabs mt-4">
               <div className="d-flex">
                 <Form.Select
                   aria-label="Default select example"

--- a/Consultify-salon/src/pages/ConsultationPresents.js
+++ b/Consultify-salon/src/pages/ConsultationPresents.js
@@ -152,7 +152,7 @@ export default function ConsultationPresents() {
     navigate(
       "/edit-consultation-presets-form?id=" +
         encodedEncrypted +
-        "&path=consultation-presents"
+        "&path=consultation-presets"
     );
   }, []);
 
@@ -192,7 +192,7 @@ export default function ConsultationPresents() {
         </Row>
       </section>
       <section>
-        <div className="consultation-presents-tabs">
+        <div className="consultation-presets-tabs">
           <div className="d-flex">
             <Form.Select
               aria-label="Default select example"
@@ -273,7 +273,7 @@ export default function ConsultationPresents() {
                     to={
                       "/consultation-preset-view/" +
                       Encryptedid(item?._id) +
-                      "/consultation-presents"
+                      "/consultation-presets"
                     }
                   >
                     View
@@ -418,7 +418,7 @@ export default function ConsultationPresents() {
                   to={
                     "/attach-presets-view/" +
                     Encryptedid(item?._id) +
-                    "/consultation-presents"
+                    "/consultation-presets"
                   }
                 >
                   View

--- a/Consultify-salon/src/pages/ConsultationPresetsVoltwo.js
+++ b/Consultify-salon/src/pages/ConsultationPresetsVoltwo.js
@@ -151,7 +151,7 @@ export default function ConsultationPresetsVoltwo({
               alt="logo"
             />
           </Navbar.Brand>
-          <NavLink className="exit_btn" to="/consultation-presents">
+          <NavLink className="exit_btn" to="/consultation-presets">
             Exit
           </NavLink>
         </Container>

--- a/Consultify-salon/src/pages/CreateConsultationFormvoltwo.js
+++ b/Consultify-salon/src/pages/CreateConsultationFormvoltwo.js
@@ -73,7 +73,7 @@ export default function CreateConsultationFormVoltwo({
               alt="logo"
             />
           </Navbar.Brand>
-          <NavLink className="exit_btn" to="/consultation-presents">
+          <NavLink className="exit_btn" to="/consultation-presets">
             Exit
           </NavLink>
         </Container>

--- a/Consultify-salon/src/pages/CreateConsultationOptions.js
+++ b/Consultify-salon/src/pages/CreateConsultationOptions.js
@@ -36,7 +36,7 @@ export default function CreateConsultationOptions({}) {
               alt="logo"
             />
           </Navbar.Brand>
-          <NavLink className="exit_btn" to="/consultation-presents">
+          <NavLink className="exit_btn" to="/consultation-presets">
             Exit
           </NavLink>
         </Container>

--- a/Consultify-salon/src/pages/CustomEmail.js
+++ b/Consultify-salon/src/pages/CustomEmail.js
@@ -37,7 +37,7 @@ export default function CustomEmail() {
         </Row>
       </section>
       <section>
-        <div className="consultation-presents-tabs">
+        <div className="consultation-presets-tabs">
           <div className="d-flex">
             <button type="button" className="active-tab mob-hide">
               View All <span>(4)</span>

--- a/Consultify-salon/src/pages/PreCare.js
+++ b/Consultify-salon/src/pages/PreCare.js
@@ -352,7 +352,7 @@ export default function PreCare() {
       )}
       {selecteddrop == 1 && (
         <>
-          <section className="mb-4 consultation-presents-tabs precare d-block">
+          <section className="mb-4 consultation-presets-tabs precare d-block">
             <Row>
               <Col
                 xs={12}

--- a/Consultify-salon/src/pages/PreCareAcknowledgement.js
+++ b/Consultify-salon/src/pages/PreCareAcknowledgement.js
@@ -174,7 +174,7 @@ export default function PreCareAcknowledgement() {
       </section>
       {/* tab-links */}
       {/* search header */}
-      <section className="mb-4 consultation-presents-tabs d-block">
+      <section className="mb-4 consultation-presets-tabs d-block">
         <Row>
           <Col
             xs={12}

--- a/Consultify-salon/src/pages/PrecarePresents.js
+++ b/Consultify-salon/src/pages/PrecarePresents.js
@@ -61,7 +61,7 @@ export default function PreCarePresents() {
         </Row>
       </section>
       <section>
-        <div className="consultation-presents-tabs d-block">
+        <div className="consultation-presets-tabs d-block">
           <Row className="column-reverse">
             <Col lg={4}>
               <button type="button" className="active-tab mob-hide">

--- a/Consultify-salon/src/pages/Settings.js
+++ b/Consultify-salon/src/pages/Settings.js
@@ -79,7 +79,7 @@ export default function Settings() {
                 </Accordion.Body>
               </Accordion.Item>
             </Accordion>
-            <Link to="/consultation-presents">
+            <Link to="/consultation-presets">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="24"

--- a/Consultify-salon/src/pages/V2/Consultationpreset/CreateConsultationForm2Preset.js
+++ b/Consultify-salon/src/pages/V2/Consultationpreset/CreateConsultationForm2Preset.js
@@ -176,7 +176,7 @@ export default function CreateConsultationForm2Preset({
               alt="logo"
             />
           </Navbar.Brand>
-          <NavLink className="exit_btn" to="/consultation-presents">
+          <NavLink className="exit_btn" to="/consultation-presets">
             Exit
           </NavLink>
         </Container>
@@ -232,7 +232,7 @@ export default function CreateConsultationForm2Preset({
                 formDatavalue.draft = 0;
                 dispatch(addConsultationAction(formDatavalue)).then(
                   function () {
-                    navigate("/consultation-presents");
+                    navigate("/consultation-presets");
                   }
                 );
               } else {

--- a/Consultify-salon/src/pages/V2/Consultationpreset/CreateConsultationForm3Preset.js
+++ b/Consultify-salon/src/pages/V2/Consultationpreset/CreateConsultationForm3Preset.js
@@ -83,7 +83,7 @@ export default function CreateConsultationForm3Preset({
               alt="logo"
             />
           </Navbar.Brand>
-          <NavLink className="exit_btn" to="/consultation-presents">
+          <NavLink className="exit_btn" to="/consultation-presets">
             Exit
           </NavLink>
         </Container>

--- a/Consultify-salon/src/pages/V2/Consultationpreset/CreateConsultationForm4Preset.js
+++ b/Consultify-salon/src/pages/V2/Consultationpreset/CreateConsultationForm4Preset.js
@@ -21,7 +21,7 @@ export default function CreateConsultationForm4Preset({ formData, prevStep }) {
   const submitform = () => {
     console.log(formData, "formData");
     dispatch(addConsultationAction(formData)).then(function () {
-      navigate("/consultation-presents");
+      navigate("/consultation-presets");
     });
   };
 
@@ -64,7 +64,7 @@ export default function CreateConsultationForm4Preset({ formData, prevStep }) {
               alt="logo"
             />
           </Navbar.Brand>
-          <NavLink className="exit_btn" to="/consultation-presents">
+          <NavLink className="exit_btn" to="/consultation-presets">
             Exit
           </NavLink>
         </Container>

--- a/Consultify-salon/src/pages/V2/Consultationpreset/CreateConsultationFormPreset.js
+++ b/Consultify-salon/src/pages/V2/Consultationpreset/CreateConsultationFormPreset.js
@@ -74,7 +74,7 @@ export default function CreateConsultationFormPreset({
               alt="logo"
             />
           </Navbar.Brand>
-          <NavLink className="exit_btn" to="/consultation-presents">
+          <NavLink className="exit_btn" to="/consultation-presets">
             Exit
           </NavLink>
         </Container>

--- a/Consultify-salon/src/pages/V2/Consultationpreset/EditConsultationForm2Preset.js
+++ b/Consultify-salon/src/pages/V2/Consultationpreset/EditConsultationForm2Preset.js
@@ -152,7 +152,7 @@ export default function EditConsultationForm2Preset({
               alt="logo"
             />
           </Navbar.Brand>
-          <NavLink className="exit_btn" to="/consultation-presents">
+          <NavLink className="exit_btn" to="/consultation-presets">
             Exit
           </NavLink>
         </Container>

--- a/Consultify-salon/src/pages/V2/Consultationpreset/EditConsultationForm3Preset.js
+++ b/Consultify-salon/src/pages/V2/Consultationpreset/EditConsultationForm3Preset.js
@@ -76,7 +76,7 @@ export default function EditConsultationForm3Preset({
               alt="logo"
             />
           </Navbar.Brand>
-          <NavLink className="exit_btn" to="/consultation-presents">
+          <NavLink className="exit_btn" to="/consultation-presets">
             Exit
           </NavLink>
         </Container>

--- a/Consultify-salon/src/pages/V2/Consultationpreset/EditConsultationFormPreset.js
+++ b/Consultify-salon/src/pages/V2/Consultationpreset/EditConsultationFormPreset.js
@@ -74,7 +74,7 @@ export default function EditConsultationFormPreset({
               alt="logo"
             />
           </Navbar.Brand>
-          <NavLink className="exit_btn" to="/consultation-presents">
+          <NavLink className="exit_btn" to="/consultation-presets">
             Exit
           </NavLink>
         </Container>

--- a/Consultify-salon/src/pages/V2/Editpreconsultationpreset/EditConsultationForm3Preset.js
+++ b/Consultify-salon/src/pages/V2/Editpreconsultationpreset/EditConsultationForm3Preset.js
@@ -121,7 +121,7 @@ export default function EditConsultationForm3Preset({
   // const submitform = () => {
 
   //   dispatch(addConsultationAction(formDatavalue)).then(function () {
-  //     navigate("/consultation-presents");
+  //     navigate("/consultation-presets");
   //   });
   // };
 


### PR DESCRIPTION
## Summary
- stretch consultation presets filter width for desktop
- rename route and links from `consultation-presents` to `consultation-presets`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3221cd80832da5f959183e849ea4